### PR TITLE
Polish and restructure GitHub profile README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,91 @@
-# 📊 GitHub Stats:
-![](https://github-readme-stats.vercel.app/api?username=HabibUrRehmanBhattii&theme=dark&hide_border=false&include_all_commits=true&count_private=true)<br/>
-![](https://github-readme-streak-stats.herokuapp.com/?user=HabibUrRehmanBhattii&theme=dark&hide_border=false)<br/>
-![](https://github-readme-stats.vercel.app/api/top-langs/?username=HabibUrRehmanBhattii&theme=dark&hide_border=false&include_all_commits=true&count_private=true&layout=compact)
+<div align="center">
 
-## 🏆 GitHub Trophies
-![](https://github-profile-trophy.vercel.app/?username=HabibUrRehmanBhattii&theme=radical&no-frame=false&no-bg=true&margin-w=4)
+# Hi there, I'm Habib Ur Rehman Bhatti 👋
 
-### ✍️ Random Dev Quote
-![](https://quotes-github-readme.vercel.app/api?type=horizontal&theme=radical)
+### Building clean, useful, and scalable digital experiences.
+
+<p>
+  <a href="https://github.com/HabibUrRehmanBhattii">
+    <img src="https://komarev.com/ghpvc/?username=HabibUrRehmanBhattii&label=Profile%20Views&color=0e75b6&style=for-the-badge" alt="profile views" />
+  </a>
+  <a href="https://github.com/HabibUrRehmanBhattii?tab=followers">
+    <img src="https://img.shields.io/github/followers/HabibUrRehmanBhattii?label=Followers&style=for-the-badge" alt="followers" />
+  </a>
+  <a href="https://github.com/HabibUrRehmanBhattii?tab=repositories">
+    <img src="https://img.shields.io/badge/Focus-Quality%20%7C%20Consistency%20%7C%20Growth-111827?style=for-the-badge" alt="focus" />
+  </a>
+</p>
+
+</div>
 
 ---
-[![](https://visitcount.itsvg.in/api?id=HabibUrRehmanBhattii&icon=0&color=0)](https://visitcount.itsvg.in)
 
-<!-- Proudly created with GPRM ( https://gprm.itsvg.in ) -->
+## 🚀 About Me
+
+I'm a developer who enjoys turning ideas into practical products with a strong focus on:
+
+- crafting clean user experiences
+- writing maintainable, readable code
+- improving performance and reliability
+- continuously learning and shipping better work
+
+I aim to build projects that are not just functional, but polished, thoughtful, and genuinely useful.
+
+## 💼 What I Focus On
+
+- **Frontend experiences** that feel fast, modern, and intuitive
+- **Full-stack development** with solid structure and maintainability
+- **Continuous improvement** through iteration, experimentation, and refinement
+- **Developer discipline** through better code quality, consistency, and clarity
+
+## 🧰 Tech Stack
+
+<p>
+  <img src="https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white" alt="HTML5" />
+  <img src="https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=css3&logoColor=white" alt="CSS3" />
+  <img src="https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black" alt="JavaScript" />
+  <img src="https://img.shields.io/badge/TypeScript-3178C6?style=for-the-badge&logo=typescript&logoColor=white" alt="TypeScript" />
+  <img src="https://img.shields.io/badge/React-20232A?style=for-the-badge&logo=react&logoColor=61DAFB" alt="React" />
+  <img src="https://img.shields.io/badge/Node.js-339933?style=for-the-badge&logo=nodedotjs&logoColor=white" alt="Node.js" />
+  <img src="https://img.shields.io/badge/Git-F05032?style=for-the-badge&logo=git&logoColor=white" alt="Git" />
+  <img src="https://img.shields.io/badge/GitHub-181717?style=for-the-badge&logo=github&logoColor=white" alt="GitHub" />
+</p>
+
+## 🌟 Developer Mindset
+
+> Build with intention. Improve with consistency. Deliver with quality.
+
+A great project is more than code — it's clarity, usability, performance, and trust working together.
+
+## 📈 GitHub Analytics
+
+<div align="center">
+  <img height="165" src="https://github-readme-stats.vercel.app/api?username=HabibUrRehmanBhattii&show_icons=true&theme=tokyonight&hide_border=true&include_all_commits=true&count_private=true" alt="GitHub stats" />
+  <img height="165" src="https://github-readme-streak-stats.herokuapp.com/?user=HabibUrRehmanBhattii&theme=tokyonight&hide_border=true" alt="GitHub streak" />
+</div>
+
+<div align="center">
+  <img height="165" src="https://github-readme-stats.vercel.app/api/top-langs/?username=HabibUrRehmanBhattii&theme=tokyonight&hide_border=true&layout=compact" alt="Top languages" />
+</div>
+
+## 🏆 Achievements
+
+<div align="center">
+  <img src="https://github-profile-trophy.vercel.app/?username=HabibUrRehmanBhattii&theme=algolia&no-frame=true&no-bg=true&margin-w=12&margin-h=12" alt="GitHub trophies" />
+</div>
+
+## ✍️ Quote That Matches the Journey
+
+<div align="center">
+  <img src="https://quotes-github-readme.vercel.app/api?type=horizontal&theme=tokyonight" alt="Random dev quote" />
+</div>
+
+## 🤝 Let's Connect
+
+If you value thoughtful development, polished work, and constant growth, let's connect and build something meaningful.
+
+---
+
+<div align="center">
+  <sub>Designed to reflect growth, consistency, and craftsmanship.</sub>
+</div>


### PR DESCRIPTION
### Motivation
- Replace a bare stats-only README with a more professional, branded profile that communicates skills, focus, and intent. 
- Make the landing content clearer and more welcoming to visitors by adding a hero, focused sections, and consistent visual styling. 
- Improve perceived quality and discoverability of the profile with structured sections and curated badges.

### Description
- Rewrote `README.md` to add a centered hero section with name, headline, and a row of profile badges. 
- Introduced structured sections: `About Me`, `What I Focus On`, `Tech Stack`, `Developer Mindset`, `GitHub Analytics`, `Achievements`, `Quote`, and `Let's Connect`. 
- Reorganized analytics and trophy widgets into a cohesive, centered layout and replaced the previous raw widget dump and visit counter. 
- Updated visual presentation using consistent shields, centered divs, and a short footer note; total change affects only `README.md` (approx. 86 insertions, 10 deletions).

### Testing
- Reviewed the patch with `git diff -- README.md` to confirm the intended changes and structure; this succeeded. 
- Inspected the resulting file with `nl -ba README.md | sed -n '1,220p'` to validate content and ordering; this succeeded. 
- Committed the change with `git commit -m "Improve profile README presentation"`, and `git diff --stat HEAD~1 HEAD` reported the file changes; commit succeeded. 
- Attempted to run `markdownlint README.md`, but the command is not available in the environment (not executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf5892a3fc83309b043270506ab03f)